### PR TITLE
Fix "Unknown setting: metric" error with dovecot 2.3

### DIFF
--- a/samples/dovecot/dovecot23.conf
+++ b/samples/dovecot/dovecot23.conf
@@ -404,7 +404,7 @@ service managesieve-login {
 }
 
 metric imap_command_finished {
-    event_name = imap_command_finished
+    filter = event=imap_command_finished
 }
 
 namespace {


### PR DESCRIPTION
Tested on FreeBSD, dovecot didn't start with the sample config. With this line it starts up fine.